### PR TITLE
解决编译后静态库调用crash的问题

### DIFF
--- a/tools/build-openssl_111_4android.sh
+++ b/tools/build-openssl_111_4android.sh
@@ -20,7 +20,7 @@ set -u
 
 OPENSSL_VERSION=1.1.1a
 
-API_LEVEL=23
+API_LEVEL=16
 
 SOURCE="$0"
 while [ -h "$SOURCE" ]; do


### PR DESCRIPTION
修复API_LEVEL太高导致的静态库不可用问题