### PR TITLE
Add an error prompt for iOS build script

### DIFF
--- a/tools/build-openssl4ios.sh
+++ b/tools/build-openssl4ios.sh
@@ -71,7 +71,13 @@ configure_make()
        ./Configure iphoneos-cross --prefix="${PREFIX_DIR}"
    fi
    export CFLAGS="-isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK}"
-
+   
+   if [ ! -d ${CROSS_TOP}/SDKs/${CROSS_SDK} ]; then
+       echo "ERROR: iOS SDK version:'${SDK_VERSION}' incorrect, SDK in your system is:"
+       xcodebuild -showsdks | grep iOS
+       exit -1
+   fi
+   
    make clean
    if make -j8
    then


### PR DESCRIPTION
Check SDK_VERSION macro, if it is invalid, show error, and display the query result.