### PR TITLE
Github CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,199 @@
+#
+#  OpenSSL for iOS and Android - CI Workflow
+#          Created by Leso_KN - 2020
+#
+
+name: CI
+
+on: [push]
+
+##
+
+jobs:
+  generate-release:
+    runs-on: macos-latest
+    steps:
+      - name: Generate Data
+        run: |
+          sha="${{ github.sha }}" && echo "short_sha=${sha:0:8}" >> $GITHUB_ENV
+          dt="${{ github.event.commits[0].timestamp }}" && echo "release_date=${dt:0:10}" >> $GITHUB_ENV
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ci-release-${{ env.short_sha }}
+          release_name: Release ${{ env.release_date }}
+          draft: false
+          prerelease: false
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+##
+
+  openssl-nghttp2:
+    strategy:
+      matrix:
+        target: [ios, android]
+        component: [openssl, nghttp2]
+        include:
+          
+          # iOS Configuration
+          - target: ios
+            arch: arm64
+            sdk: iphoneos
+            api: "8.0"
+            platform: iPhoneOS
+
+          # Android Configuration
+          - target: android
+            arch: arm64
+            abi: arm64-v8a
+            api: 23
+
+          # OpenSSL version
+          - component: openssl
+            version: "1.1.1d"
+
+          # nghttp2 version
+          - component: nghttp2
+            version: "1.40.0"
+
+      fail-fast: false
+
+    runs-on: macos-latest
+    needs: [generate-release]
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Setup Environment Variables
+        run: |
+          set -x
+          export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_ROOT" >> $GITHUB_ENV
+
+          echo "arch=${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "abi=${{ matrix.abi }}" >> $GITHUB_ENV
+          echo "sdk=${{ matrix.sdk }}" >> $GITHUB_ENV
+          echo "api=${{ matrix.api }}" >> $GITHUB_ENV
+          echo "platform=${{ matrix.platform }}" >> $GITHUB_ENV
+          echo "version=${{ matrix.version }}" >> $GITHUB_ENV
+          
+          echo "product_dir=${{ matrix.component }}_${{ matrix.version }}-${{ matrix.target }}-${{ matrix.arch }}" >> $GITHUB_ENV
+
+          source $GITHUB_ENV
+          set
+      - name: Build ${{ matrix.component }} for ${{ matrix.target }}
+        run: |
+          cd tools
+          ./build-${{ matrix.target }}-${{ matrix.component }}.sh
+          cd ..
+          mkdir -p "$product_dir/"{lib,include}
+          mv "output/${{ matrix.target }}/${{ matrix.component }}-${{ matrix.abi || matrix.arch }}/"{lib,include} "$product_dir/" || true
+        if: always()
+      - name: Upload Binaries
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ env.product_dir }}
+          path: ./${{ env.product_dir }}
+        if: always()
+      - name: Zip Binaries
+        run: |
+          cd "$product_dir"
+          zip -r ../$product_dir.zip *
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.generate-release.outputs.upload_url }}
+          asset_path: ${{ env.product_dir }}.zip
+          asset_name: ${{ env.product_dir }}.zip
+          asset_content_type: application/zip
+
+##
+
+  curl:
+    strategy:
+      matrix:
+        target: [ios, android]
+        component: [curl]
+        include:
+                    
+          # iOS Configuration
+          - target: ios
+            arch: arm64
+            sdk: iphoneos
+            api: "8.0"
+            platform: iPhoneOS
+
+          # Android Configuration
+          - target: android
+            arch: arm64
+            abi: arm64-v8a
+            api: 23
+
+          # cURL version
+          - component: curl
+            version: "7.68.0"
+
+      fail-fast: false
+
+    runs-on: macos-latest
+    needs: [generate-release, openssl-nghttp2]
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Setup Environment Variables
+        run: |
+          set -x
+          export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_ROOT" >> $GITHUB_ENV
+
+          echo "arch=${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "abi=${{ matrix.abi }}" >> $GITHUB_ENV
+          echo "sdk=${{ matrix.sdk }}" >> $GITHUB_ENV
+          echo "api=${{ matrix.api }}" >> $GITHUB_ENV
+          echo "platform=${{ matrix.platform }}" >> $GITHUB_ENV
+          echo "version=${{ matrix.version }}" >> $GITHUB_ENV
+          
+          echo "product_dir=${{ matrix.component }}_${{ matrix.version }}-${{ matrix.target }}-${{ matrix.arch }}" >> $GITHUB_ENV
+
+          source $GITHUB_ENV
+          set
+      - name: Build ${{ matrix.component }} for ${{ matrix.target }}
+        run: |
+          cd tools
+          ./build-${{ matrix.target }}-${{ matrix.component }}.sh
+          cd ..
+          mkdir -p "$product_dir/"{lib,include}
+          mv "output/${{ matrix.target }}/${{ matrix.component }}-${{ matrix.abi || matrix.arch }}/"{lib,include} "$product_dir/" || true
+        if: always()
+      - name: Upload Binaries
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ env.product_dir }}
+          path: ./${{ env.product_dir }}
+        if: always()
+      - name: Zip Binaries
+        run: |
+          cd "$product_dir"
+          zip -r ../$product_dir.zip *
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.generate-release.outputs.upload_url }}
+          asset_path: ${{ env.product_dir }}.zip
+          asset_name: ${{ env.product_dir }}.zip
+          asset_content_type: application/zip

--- a/tools/build-android-common.sh
+++ b/tools/build-android-common.sh
@@ -17,10 +17,10 @@
 source ./build-common.sh
 
 export PLATFORM_TYPE="Android"
-export ARCHS=("arm" "arm64" "x86" "x86_64")
-export ABIS=("armeabi-v7a" "arm64-v8a" "x86" "x86_64")
-export ABI_TRIPLES=("arm-linux-androideabi" "aarch64-linux-android" "i686-linux-android" "x86_64-linux-android")
-export ANDROID_API=23
+export ARCHS=("$arch")
+export ABIS=("$abi")
+export ABI_TRIPLES=("$arch-linux-android")
+export ANDROID_API=$api
 
 # for test
 # export ARCHS=("x86_64")

--- a/tools/build-android-curl.sh
+++ b/tools/build-android-curl.sh
@@ -35,8 +35,8 @@ pwd_path="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 echo pwd_path=${pwd_path}
 echo TOOLS_ROOT=${TOOLS_ROOT}
 
-LIB_VERSION="curl-7_68_0"
-LIB_NAME="curl-7.68.0"
+LIB_VERSION="curl-$(echo $version | sed 's/\./_/g')"
+LIB_NAME="curl-$version"
 LIB_DEST_DIR="${pwd_path}/../output/android/curl-universal"
 
 echo "https://github.com/curl/curl/releases/download/${LIB_VERSION}/${LIB_NAME}.tar.gz"

--- a/tools/build-android-nghttp2.sh
+++ b/tools/build-android-nghttp2.sh
@@ -35,8 +35,8 @@ pwd_path="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 echo pwd_path=${pwd_path}
 echo TOOLS_ROOT=${TOOLS_ROOT}
 
-LIB_VERSION="v1.40.0"
-LIB_NAME="nghttp2-1.40.0"
+LIB_VERSION="v$version"
+LIB_NAME="nghttp2-$version"
 LIB_DEST_DIR="${pwd_path}/../output/android/nghttp2-universal"
 
 echo "https://github.com/nghttp2/nghttp2/releases/download/${LIB_VERSION}/${LIB_NAME}.tar.gz"

--- a/tools/build-android-openssl.sh
+++ b/tools/build-android-openssl.sh
@@ -37,8 +37,8 @@ echo TOOLS_ROOT=${TOOLS_ROOT}
 
 # openssl-1.1.0f has a configure bug
 # openssl-1.1.1d has fix configure bug
-LIB_VERSION="OpenSSL_1_1_1d"
-LIB_NAME="openssl-1.1.1d"
+LIB_VERSION="OpenSSL_$(echo $version | sed 's/\./_/g')"
+LIB_NAME="openssl-$version"
 LIB_DEST_DIR="${pwd_path}/../output/android/openssl-universal"
 
 echo "https://www.openssl.org/source/${LIB_NAME}.tar.gz"

--- a/tools/build-common.sh
+++ b/tools/build-common.sh
@@ -30,31 +30,26 @@ function get_cpu_count() {
     fi
 }
 
+export bold_color="\033[1;m"
+export warn_color="\033[33m"
+export error_color="\033[31m"
+export reset_color="\033[0m"
+export ncols=80
+
 function init_log_color() {
-    if test -t 1 && which tput >/dev/null 2>&1; then
-        ncolors=$(tput colors)
-        if test -n "$ncolors" && test $ncolors -ge 8; then
-            bold_color=$(tput bold)
-            warn_color=$(tput setaf 3)
-            error_color=$(tput setaf 1)
-            reset_color=$(tput sgr0)
-        fi
-        # 72 used instead of 80 since that's the default of pr
-        ncols=$(tput cols)
-    fi
-    : ${ncols:=72}
+    true
 }
 
 function log_info() {
-    echo "$warn_color$@$reset_color"
+    printf "$warn_color$@$reset_color\n"
 }
 
 function log_warning() {
-    echo "$warn_color$bold_color$@$reset_color"
+    printf "$warn_color$bold_color$@$reset_color\n"
 }
 
 function log_error() {
-    echo "$error_color$bold_color$@$reset_color"
+    printf "$error_color$bold_color$@$reset_color\n"
 }
 
 # init_log_color

--- a/tools/build-ios-common.sh
+++ b/tools/build-ios-common.sh
@@ -17,10 +17,10 @@
 source ./build-common.sh
 
 export PLATFORM_TYPE="iOS"
-export IOS_MIN_TARGET="8.0"
-export ARCHS=("armv7" "arm64" "arm64e" "x86_64")
-export SDKS=("iphoneos" "iphoneos" "iphoneos" "iphonesimulator")
-export PLATFORMS=("iPhoneOS" "iPhoneOS" "iphoneos" "iPhoneSimulator")
+export IOS_MIN_TARGET="$api"
+export ARCHS=("$arch")
+export SDKS=("$sdk")
+export PLATFORMS=("$platform")
 
 # for test !!!
 # export ARCHS=("armv7")

--- a/tools/build-ios-curl.sh
+++ b/tools/build-ios-curl.sh
@@ -33,8 +33,8 @@ pwd_path="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 echo pwd_path=${pwd_path}
 echo TOOLS_ROOT=${TOOLS_ROOT}
 
-LIB_VERSION="curl-7_68_0"
-LIB_NAME="curl-7.68.0"
+LIB_VERSION="curl-$(echo $version | sed 's/\./_/g')"
+LIB_NAME="curl-$version"
 LIB_DEST_DIR="${pwd_path}/../output/ios/curl-universal"
 
 init_log_color

--- a/tools/build-ios-nghttp2.sh
+++ b/tools/build-ios-nghttp2.sh
@@ -33,8 +33,8 @@ pwd_path="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 echo pwd_path=${pwd_path}
 echo TOOLS_ROOT=${TOOLS_ROOT}
 
-LIB_VERSION="v1.40.0"
-LIB_NAME="nghttp2-1.40.0"
+LIB_VERSION="v$version"
+LIB_NAME="nghttp2-$version"
 LIB_DEST_DIR="${pwd_path}/../output/ios/nghttp2-universal"
 
 init_log_color

--- a/tools/build-ios-openssl.sh
+++ b/tools/build-ios-openssl.sh
@@ -35,8 +35,8 @@ echo TOOLS_ROOT=${TOOLS_ROOT}
 
 # openssl-1.1.0f has a configure bug
 # openssl-1.1.1d has fix configure bug
-LIB_VERSION="OpenSSL_1_1_1d"
-LIB_NAME="openssl-1.1.1d"
+LIB_VERSION="OpenSSL_$(echo $version | sed 's/\./_/g')"
+LIB_NAME="openssl-$version"
 LIB_DEST_DIR="${pwd_path}/../output/ios/openssl-universal"
 
 init_log_color


### PR DESCRIPTION
Hi,

I've created a github ci workflow for this project.

It can be configured to build any version of `openssl`, `nghttp2` and `curl` for both, ios and android automatically on push events (or whatever repository event, like `pull-request`).

Library versions, target architectures, -platforms, -abis, -api versions etc can be adjusted from inside a single workflow file (`ci.yml`).

The pipeline automatically creates releases and attaches the compiled files. For a preview, check the [releases section](https://github.com/leso-kn/openssl_for_ios_and_android/releases/tag/ci-release-2b6c1348) of my fork.

---

:warning: **Please beware:** Github workflows do not support yaml anchors at the moment.

Yaml anchors are a technique to re-use sections of yaml code. Since this feature is missing at the moment and the build step for `curl` depends on `openssl` and `nghttp2`, the workflow configuration file is a bit large right now.

Support for yaml anchors in gitlab workflows is planned in the future. This will allow to shorten the contents of the ci config.