### PR TITLE
[Android] Remove XCODE tools, update libraries and README.md, remove ANDROID_HOME check

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ If you do not want to build it by yourself, you could download our prebuilt libr
  - ~~[openssl-1.0.2c.tar.gz](https://www.openssl.org/source/openssl-1.0.2c.tar.gz)~~
  - [openssl-1.1.0f.tar.gz](https://www.openssl.org/source/openssl-1.1.0f.tar.gz)
  - [openssl-1.1.1d.tar.gz](https://www.openssl.org/source/openssl-1.1.1d.tar.gz)
+ - [openssl-1.1.1i.tar.gz](https://www.openssl.org/source/openssl-1.1.1i.tar.gz)
  - [https://github.com/openssl/openssl](https://github.com/openssl/openssl)
 
 ## nghttp2 Version
 
  - [nghttp2-1.40.0.tar.gz](https://github.com/nghttp2/nghttp2/releases/download/v1.40.0/nghttp2-1.40.0.tar.gz)
+ - [nghttp2-1.42.0.tar.gz](https://github.com/nghttp2/nghttp2/releases/download/v1.42.0/nghttp2-1.42.0.tar.gz)
  - [https://nghttp2.org/](https://nghttp2.org/)
 
 ## cURL Version
@@ -38,6 +40,7 @@ If you do not want to build it by yourself, you could download our prebuilt libr
  - ~~[curl-7.47.1.tar.gz](https://curl.haxx.se/download/curl-7.47.1.tar.gz)~~
  - [curl-7.66.0.tar.gz](https://curl.haxx.se/download/curl-7.66.0.tar.gz)
  - [curl-7.68.0.tar.gz](https://curl.haxx.se/download/curl-7.68.0.tar.gz)
+ - [curl-7.74.0.tar.gz](https://curl.haxx.se/download/curl-7.74.0.tar.gz)
  - [https://github.com/curl/curl](https://github.com/curl/curl)
 
 ## Android NDK Version
@@ -45,6 +48,7 @@ If you do not want to build it by yourself, you could download our prebuilt libr
  - ~~[android-ndk-r13b](https://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip)~~
  - ~~[android-ndk-r14b](https://dl.google.com/android/repository/android-ndk-r14b-darwin-x86_64.zip)~~
  - ~~android-ndk-r15 (**Do not try to build use 15 It will fail**)~~
+ - [android-ndk-r21d-darwin](https://dl.google.com/android/repository/android-ndk-r21d-darwin-x86_64.zip) [android-ndk-r21d-linux](https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip)
  - support api 23 above
 
 ## How to build
@@ -69,24 +73,28 @@ $ sh build-ios-curl.sh
 
 ### For Android
 
-- Android Studio info: 3.5.3 (for reference only)
+- Android Studio info: 4.1, November 5, 2020 (for reference only)
+- Android NDK info: r21d
 - Build dependencies: todo
 - Build order: 1.build openssl, 2.build nghttp2, 3.build curl (curl depend openssl and nghttp2)
 - build static library(.a) and dynamic library (exclude curl arm64-v8a)
 - env macro: for example:
 ```
-export ANDROID_HOME=/Users/userid/Library/Android/sdk
-export ANDROID_NDK_ROOT=$ANDROID_HOME/ndk-bundle
+export ANDROID_NDK_ROOT=/Location/where/installed/android-ndk-r21d
 
 ```
 - build sh cmd: for example:
 ```
 $ cd tools
-$ sh build-android-openssl.sh
-$ sh build-android-nghttp2.sh
-$ sh build-android-curl.sh
+$ export api=16
+$ ./build-android-openssl.sh arm
+$ ./build-android-nghttp2.sh arm
+$ ./build-android-curl.sh arm
+$ export api=21
+$ ./build-android-openssl.sh arm64
+$ ./build-android-nghttp2.sh arm64
+$ ./build-android-curl.sh arm64
 ```
-
 
 
 > **You must build openssl and nghttp2(support http2) first**

--- a/tools/build-android-common.sh
+++ b/tools/build-android-common.sh
@@ -40,11 +40,6 @@ if [[ -z ${ANDROID_NDK_ROOT} ]]; then
   exit 1
 fi
 
-if [[ -z ${ANDROID_HOME} ]]; then
-  echo "ANDROID_HOME not defined"
-  exit 1
-fi
-
 function get_toolchain() {
   HOST_OS=$(uname -s)
   case ${HOST_OS} in

--- a/tools/build-android-curl.sh
+++ b/tools/build-android-curl.sh
@@ -21,7 +21,7 @@ set -u
 source ./build-android-common.sh
 
 if [ -z ${version+x} ]; then 
-  version="7.68.0"
+  version="7.74.0"
 fi
 
 init_log_color
@@ -48,8 +48,6 @@ echo "https://github.com/curl/curl/releases/download/${LIB_VERSION}/${LIB_NAME}.
 # https://curl.haxx.se/download/${LIB_NAME}.tar.gz
 # https://github.com/curl/curl/releases/download/curl-7_69_0/curl-7.69.0.tar.gz
 # https://github.com/curl/curl/releases/download/curl-7_68_0/curl-7.68.0.tar.gz
-DEVELOPER=$(xcode-select -print-path)
-SDK_VERSION=$(xcrun -sdk iphoneos --show-sdk-version)
 rm -rf "${LIB_DEST_DIR}" "${LIB_NAME}"
 [ -f "${LIB_NAME}.tar.gz" ] || curl -LO https://github.com/curl/curl/releases/download/${LIB_VERSION}/${LIB_NAME}.tar.gz >${LIB_NAME}.tar.gz
 

--- a/tools/build-android-lz4.sh
+++ b/tools/build-android-lz4.sh
@@ -41,8 +41,6 @@ LIB_DEST_DIR="${pwd_path}/../output/android/lz4"
 
 #echo "https://github.com/lz4/lz4/releases/download/${LIB_VERSION}/${LIB_NAME}.tar.gz"
 
-DEVELOPER=$(xcode-select -print-path)
-SDK_VERSION=$(xcrun -sdk iphoneos --show-sdk-version)
 rm -rf "${LIB_DEST_DIR}" "${LIB_NAME}"
 [ -f "${LIB_NAME}.tar.gz" ] || curl -L https://github.com/lz4/lz4/archive/${LIB_VERSION}.tar.gz >${LIB_NAME}.tar.gz
 

--- a/tools/build-android-nghttp2.sh
+++ b/tools/build-android-nghttp2.sh
@@ -21,7 +21,7 @@ set -u
 source ./build-android-common.sh
 
 if [ -z ${version+x} ]; then 
-  version="1.40.0"
+  version="1.42.0"
 fi
 
 init_log_color
@@ -45,8 +45,6 @@ LIB_DEST_DIR="${pwd_path}/../output/android/nghttp2-universal"
 
 echo "https://github.com/nghttp2/nghttp2/releases/download/${LIB_VERSION}/${LIB_NAME}.tar.gz"
 
-DEVELOPER=$(xcode-select -print-path)
-SDK_VERSION=$(xcrun -sdk iphoneos --show-sdk-version)
 rm -rf "${LIB_DEST_DIR}" "${LIB_NAME}"
 [ -f "${LIB_NAME}.tar.gz" ] || curl -LO https://github.com/nghttp2/nghttp2/releases/download/${LIB_VERSION}/${LIB_NAME}.tar.gz >${LIB_NAME}.tar.gz
 

--- a/tools/build-android-openssl.sh
+++ b/tools/build-android-openssl.sh
@@ -21,7 +21,7 @@ set -u
 source ./build-android-common.sh
 
 if [ -z ${version+x} ]; then 
-  version="1.1.1d"
+  version="1.1.1i"
 fi
 
 init_log_color
@@ -49,8 +49,6 @@ echo "https://www.openssl.org/source/${LIB_NAME}.tar.gz"
 
 # https://github.com/openssl/openssl/archive/OpenSSL_1_1_1d.tar.gz
 # https://github.com/openssl/openssl/archive/OpenSSL_1_1_1f.tar.gz
-DEVELOPER=$(xcode-select -print-path)
-SDK_VERSION=$(xcrun -sdk iphoneos --show-sdk-version)
 rm -rf "${LIB_DEST_DIR}" "${LIB_NAME}"
 [ -f "${LIB_NAME}.tar.gz" ] || curl https://www.openssl.org/source/${LIB_NAME}.tar.gz >${LIB_NAME}.tar.gz
 

--- a/tools/build-android-rsync.sh
+++ b/tools/build-android-rsync.sh
@@ -41,11 +41,6 @@ LIB_DEST_DIR="${pwd_path}/../output/android/curl-universal"
 
 echo "https://download.samba.org/pub/rsync/${LIB_NAME}.tar.gz"
 
-# https://curl.haxx.se/download/${LIB_NAME}.tar.gz
-# https://github.com/curl/curl/releases/download/curl-7_69_0/curl-7.69.0.tar.gz
-# https://github.com/curl/curl/releases/download/curl-7_68_0/curl-7.68.0.tar.gz
-DEVELOPER=$(xcode-select -print-path)
-SDK_VERSION=$(xcrun -sdk iphoneos --show-sdk-version)
 rm -rf "${LIB_DEST_DIR}" "${LIB_NAME}"
 [ -f "${LIB_NAME}.tar.gz" ] || curl -LO https://download.samba.org/pub/rsync/${LIB_NAME}.tar.gz >${LIB_NAME}.tar.gz
 

--- a/tools/build-android-xxhash.sh
+++ b/tools/build-android-xxhash.sh
@@ -41,8 +41,6 @@ LIB_DEST_DIR="${pwd_path}/../output/android/xxhash"
 
 #echo "https://github.com/xxhash/xxhash/releases/download/${LIB_VERSION}/${LIB_NAME}.tar.gz"
 
-DEVELOPER=$(xcode-select -print-path)
-SDK_VERSION=$(xcrun -sdk iphoneos --show-sdk-version)
 rm -rf "${LIB_DEST_DIR}" "${LIB_NAME}"
 [ -f "${LIB_NAME}.tar.gz" ] || curl -L https://github.com/Cyan4973/xxHash/archive/${LIB_VERSION}.tar.gz >${LIB_NAME}.tar.gz
 

--- a/tools/build-android-zstd.sh
+++ b/tools/build-android-zstd.sh
@@ -35,14 +35,12 @@ pwd_path="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 echo pwd_path=${pwd_path}
 echo TOOLS_ROOT=${TOOLS_ROOT}
 
-LIB_VERSION="v1.4.5"
-LIB_NAME="zstd-1.4.5"
+LIB_VERSION="v1.4.8"
+LIB_NAME="zstd-1.4.8"
 LIB_DEST_DIR="${pwd_path}/../output/android/zstd"
 
 #echo "https://github.com/zstd/zstd/releases/download/${LIB_VERSION}/${LIB_NAME}.tar.gz"
 
-DEVELOPER=$(xcode-select -print-path)
-SDK_VERSION=$(xcrun -sdk iphoneos --show-sdk-version)
 rm -rf "${LIB_DEST_DIR}" "${LIB_NAME}"
 [ -f "${LIB_NAME}.tar.gz" ] || curl -L https://github.com/facebook/zstd/archive/${LIB_VERSION}.tar.gz >${LIB_NAME}.tar.gz
 


### PR DESCRIPTION
- Remove XCODE tools for Android
- Update curl to 7.74.0, nghttp2 to 1.42.0, openssl to 1.1.1i, zstd to 1.4.8
- Update README.md
- Remove ANDROID_HOME check (some projects may not require)