### PR TITLE
Inhibit versioning of generated .so files as

### DIFF
--- a/tools/build-android-openssl.sh
+++ b/tools/build-android-openssl.sh
@@ -109,8 +109,11 @@ function configure_make() {
     log_info "make $ABI start..."
 
     make clean >"${OUTPUT_ROOT}/log/${ABI}.log"
-    if make -j$(get_cpu_count) >>"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1; then
-        make install_sw >>"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
+    # ABr: do *not* generate soname; see https://stackoverflow.com/a/33869277
+    make SHLIB_EXT='.so' CALC_VERSIONS="SHLIB_COMPAT=; SHLIB_SOVER=" MAKE="make -e" all >>"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
+    the_rc=$?
+    if [ $the_rc -eq 0 ] ; then
+        make SHLIB_EXT='.so' install_sw >>"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
         make install_ssldirs >>"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
     fi
 


### PR DESCRIPTION
Xamarin refuses to load .so files with a version if these files are listed as NEEDED in dependent .so files.

Example: Had to adapt https://github.com/herumi/msoffice to be consumable by Android Xamarin app. When building msoffice, it depends on libcrypto.so so used "-L[path] -lcrypto" using stock openssl_for_ios_and_android Android build. However, this failed to load at runtime because NEEDED section in the created msoffice.so file referenced "libcrypto.so.1.1" (versioned) due to setting SONAME in the generated libcrypto.so output. "Fixed" by inhibiting version...

Note: because native libs are sandboxed on iOS and Android there should not be a need for versioning *unless* there existed situation where different native libs actually required different versions of dependent .so. (Example: If one native lib requires v1.0c of libcrypto while another native lib requires v1.1.) However, this should be the rarest edge condition and I don't think the openssl_for_ios_and_android out-of-the-box build should account for it.